### PR TITLE
Add currency symbol formatting helper with tests

### DIFF
--- a/src/cashify.service.spec.ts
+++ b/src/cashify.service.spec.ts
@@ -52,4 +52,14 @@ describe('CashifyService', () => {
     let converted = cashifyService.convert('€10 EUR to GBP');
     expect(converted).toEqual(9.2);
   })
+
+  it('should convert currency with symbol', () => {
+    let converted = cashifyService.convertWithSymbol(
+      10,
+      'EUR',
+      'GBP'
+    );
+
+    expect(converted).toEqual('£9.20');
+  })
 })

--- a/src/cashify.service.ts
+++ b/src/cashify.service.ts
@@ -2,11 +2,31 @@ import { Inject, Injectable } from '@nestjs/common';
 import { Cashify } from 'cashify';
 import { CASHIFY } from './';
 
+const DEFAULT_CURRENCY_SYMBOLS = {
+  GBP: '£',
+  EUR: '€',
+  USD: '$',
+};
+
 @Injectable()
 export class CashifyService {
   constructor(@Inject(CASHIFY) private readonly cashify: Cashify) {}
 
   public convert(amount, options?) {
     return this.cashify.convert(amount, options);
+  }
+
+
+  public convertWithSymbol(amount: number | string,
+    from: string, to: string): string {
+    const converted = this.convert(amount, {
+      from: from.toUpperCase(),
+      to: to.toUpperCase(),
+    });
+
+    const symbol = DEFAULT_CURRENCY_SYMBOLS[to.toUpperCase() as keyof typeof DEFAULT_CURRENCY_SYMBOLS];
+    return symbol
+      ? `${symbol}${Number(converted).toFixed(2)}`
+      : `${to.toUpperCase()} ${converted}`;
   }
 }


### PR DESCRIPTION
This PR adds a utility method to format converted currency values with currency symbols.

## Changes

* Added `convertWithSymbol` helper method in `CashifyService`
* Added unit tests for the new functionality
* Existing convert functionality remains unchanged

## Example

```ts id="ex1"
convertWithSymbol(10, 'EUR', 'GBP')
// £9.20
```

## Testing

All tests are passing successfully:

```bash id="t1"
npx jest
```

<img width="369" height="242" alt="test method" src="https://github.com/user-attachments/assets/5cdc2eee-3bde-4cba-a634-44463badbbcb" />

